### PR TITLE
Fix old websockets syntax

### DIFF
--- a/sinric/_sinricprosocket.py
+++ b/sinric/_sinricprosocket.py
@@ -30,7 +30,7 @@ class SinricProSocket(Signature):
         Signature.__init__(self, self.secretKey)
 
     async def connect(self):  # Producer
-        self.connection = await websockets.client.connect('ws://ws.sinric.pro',
+        self.connection = await websockets.connect('ws://ws.sinric.pro',
                                                           extra_headers={'appkey': self.appKey,
                                                                          'deviceids': ';'.join(self.deviceIds),
                                                                          'platform': 'python',


### PR DESCRIPTION
This fixes `AttributeError: module 'websockets' has no attribute 'client'` error, which appears when using `client = SinricPro(....)`